### PR TITLE
Add basic Embassy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "cortex-m"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,7 +92,7 @@ dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
  "cortex-m-rtic-macros",
- "heapless",
+ "heapless 0.7.17",
  "rtic-core",
  "rtic-monotonic",
  "version_check",
@@ -121,6 +127,123 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64f84599b0f4296b92a4b6ac2109bc02340094bda47b9766c5f9ec6a318ebf8"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "document-features",
+ "embassy-executor-macros",
+ "embassy-time-driver",
+ "embassy-time-queue-driver",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3577b1e9446f61381179a330fc5324b01d511624c55f25e3c66c9e3c626dbecf"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "embassy-sync"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io-async",
+ "futures-sink",
+ "futures-util",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158080d48f824fad101d7b2fae2d83ac39e3f7a6fa01811034f7ab8ffc6e7309"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embassy-time-queue-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-util",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
+
+[[package]]
 name = "embedded-dma"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,10 +269,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "embedded-io"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "embedded-io-async"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
+dependencies = [
+ "embedded-io 0.6.1",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
 
 [[package]]
 name = "gd32f1"
@@ -171,10 +354,15 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "cortex-m-semihosting",
+ "critical-section",
+ "embassy-executor",
+ "embassy-sync",
+ "embassy-time",
+ "embassy-time-driver",
  "embedded-dma",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
- "embedded-io",
+ "embedded-io 0.7.1",
  "gd32f1",
  "nb 1.1.0",
  "panic-halt",
@@ -194,6 +382,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,11 +403,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version 0.4.0",
  "spin",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -221,6 +434,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -271,6 +490,18 @@ dependencies = [
  "cortex-m",
  "cortex-m-semihosting",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro-error"
@@ -397,6 +628,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "darling"
@@ -172,23 +172,22 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.6.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64f84599b0f4296b92a4b6ac2109bc02340094bda47b9766c5f9ec6a318ebf8"
+checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
 dependencies = [
  "cortex-m",
  "critical-section",
  "document-features",
  "embassy-executor-macros",
- "embassy-time-driver",
- "embassy-time-queue-driver",
+ "embassy-executor-timer-queue",
 ]
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3577b1e9446f61381179a330fc5324b01d511624c55f25e3c66c9e3c626dbecf"
+checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -197,51 +196,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-sync"
-version = "0.6.2"
+name = "embassy-executor-timer-queue"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
+checksum = "2fc328bf943af66b80b98755db9106bf7e7471b0cf47dc8559cd9a6be504cc9c"
+
+[[package]]
+name = "embassy-sync"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
 dependencies = [
  "cfg-if",
  "critical-section",
  "embedded-io-async",
+ "futures-core",
  "futures-sink",
- "futures-util",
  "heapless 0.8.0",
 ]
 
 [[package]]
 name = "embassy-time"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158080d48f824fad101d7b2fae2d83ac39e3f7a6fa01811034f7ab8ffc6e7309"
+checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
 dependencies = [
  "cfg-if",
  "critical-section",
  "document-features",
  "embassy-time-driver",
- "embassy-time-queue-driver",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "futures-util",
- "heapless 0.8.0",
+ "futures-core",
 ]
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
+checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
 dependencies = [
  "document-features",
 ]
 
 [[package]]
-name = "embassy-time-queue-driver"
-version = "0.1.0"
+name = "embassy-time-queue-utils"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
+checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
+dependencies = [
+ "embassy-executor-timer-queue",
+ "heapless 0.8.0",
+]
 
 [[package]]
 name = "embedded-dma"
@@ -317,24 +324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
-]
-
-[[package]]
 name = "gd32f1"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +348,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embassy-time-driver",
+ "embassy-time-queue-utils",
  "embedded-dma",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
@@ -490,18 +480,6 @@ dependencies = [
  "cortex-m",
  "cortex-m-semihosting",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ default-target = "x86_64-unknown-linux-gnu"
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.5"
 critical-section = { version = "1.1.3", optional = true }
+embassy-time-driver = { version = "0.1.0", optional = true }
+embassy-sync = { version = "0.6.0", optional = true }
 embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.7", features = [
@@ -28,19 +30,17 @@ gd32f1 = { version = "0.9.1", features = ["critical-section"] }
 nb = "1.1.0"
 thiserror = { version = "2.0.17", default-features = false }
 void = { version = "1.0.2", default-features = false, optional = true }
-embassy-executor = { version = "0.6", features = [
-  "arch-cortex-m",
-  "executor-thread",
-  "integrated-timers",
-], optional = true }
-embassy-time = { version = "0.3.2", optional = true }
-embassy-time-driver = { version = "0.1.0", optional = true }
-embassy-sync = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rtic = "1.1.4"
 cortex-m-semihosting = "0.5.0"
+embassy-executor = { version = "0.6", features = [
+  "arch-cortex-m",
+  "executor-thread",
+  "integrated-timers",
+] }
+embassy-time = { version = "0.3.2" }
 panic-halt = "1.0.0"
 panic-itm = "0.4.2"
 panic-semihosting = "0.6.0"
@@ -69,14 +69,12 @@ gd32f190x8 = ["gd32f190"]
 embassy = [
   "rt",
   "dep:critical-section",
-  "dep:embassy-executor",
   "dep:embassy-sync",
-  "dep:embassy-time",
   "dep:embassy-time-driver",
 ]
-time-driver-tim1=["embassy"]
-time-driver-tim2=["embassy"]
-time-driver-tim14=["embassy"]
+time-driver-tim1 = ["embassy"]
+time-driver-tim2 = ["embassy"]
+time-driver-tim14 = ["embassy"]
 
 [profile.dev]
 incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ embassy = [
   "dep:critical-section",
   "dep:embassy-sync",
   "dep:embassy-time-driver",
-  "dep:embassy-time-queue-utils"
+  "dep:embassy-time-queue-utils",
 ]
 time-driver-tim1 = ["embassy"]
 time-driver-tim2 = ["embassy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default-target = "x86_64-unknown-linux-gnu"
 [dependencies]
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.5"
+critical-section = { version = "1.1.3", optional = true }
 embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.7", features = [
@@ -27,6 +28,14 @@ gd32f1 = { version = "0.9.1", features = ["critical-section"] }
 nb = "1.1.0"
 thiserror = { version = "2.0.17", default-features = false }
 void = { version = "1.0.2", default-features = false, optional = true }
+embassy-executor = { version = "0.6", features = [
+  "arch-cortex-m",
+  "executor-thread",
+  "integrated-timers",
+], optional = true }
+embassy-time = { version = "0.3.2", optional = true }
+embassy-time-driver = { version = "0.1.0", optional = true }
+embassy-sync = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
@@ -57,6 +66,17 @@ gd32f190 = ["gd32f1/gd32f190", "device-selected"]
 gd32f190x4 = ["gd32f190"]
 gd32f190x6 = ["gd32f190"]
 gd32f190x8 = ["gd32f190"]
+embassy = [
+  "rt",
+  "dep:critical-section",
+  "dep:embassy-executor",
+  "dep:embassy-sync",
+  "dep:embassy-time",
+  "dep:embassy-time-driver",
+]
+time-driver-tim1=["embassy"]
+time-driver-tim2=["embassy"]
+time-driver-tim14=["embassy"]
 
 [profile.dev]
 incremental = false
@@ -110,3 +130,7 @@ required-features = ["rt"]
 #[[example]]
 #name = "can-rtic"
 #required-features = ["has-can", "rt"]
+
+[[example]]
+name = "embassy"
+required-features = ["time-driver-tim1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ default-target = "x86_64-unknown-linux-gnu"
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.5"
 critical-section = { version = "1.1.3", optional = true }
-embassy-time-driver = { version = "0.1.0", optional = true }
-embassy-sync = { version = "0.6.0", optional = true }
+embassy-time-driver = { version = "0.2.1", optional = true }
+embassy-time-queue-utils = { version = "0.3.0", optional = true }
+embassy-sync = { version = "0.7.2", optional = true }
 embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.7", features = [
@@ -35,12 +36,11 @@ void = { version = "1.0.2", default-features = false, optional = true }
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rtic = "1.1.4"
 cortex-m-semihosting = "0.5.0"
-embassy-executor = { version = "0.6", features = [
+embassy-executor = { version = "0.9.1", features = [
   "arch-cortex-m",
   "executor-thread",
-  "integrated-timers",
 ] }
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.5.0" }
 panic-halt = "1.0.0"
 panic-itm = "0.4.2"
 panic-semihosting = "0.6.0"
@@ -71,6 +71,7 @@ embassy = [
   "dep:critical-section",
   "dep:embassy-sync",
   "dep:embassy-time-driver",
+  "dep:embassy-time-queue-utils"
 ]
 time-driver-tim1 = ["embassy"]
 time-driver-tim2 = ["embassy"]

--- a/examples/embassy.rs
+++ b/examples/embassy.rs
@@ -7,10 +7,17 @@ use panic_halt as _;
 use embassy_executor::{self, Spawner};
 use embassy_time::Timer;
 use embedded_hal::digital::OutputPin;
-use gd32f1x0_hal::{embassy, pac, prelude::*, time::MilliSeconds, watchdog::FreeWatchdog};
+use gd32f1x0_hal::{
+    embassy,
+    gpio::{Output, Pin, PushPull},
+    pac,
+    prelude::*,
+    time::MilliSeconds,
+    watchdog::FreeWatchdog,
+};
 
 #[embassy_executor::task]
-async fn blink_task(mut led: impl OutputPin + 'static) {
+async fn blink_task(mut led: Pin<Output<PushPull>>) {
     loop {
         Timer::after_millis(1_000).await;
         led.set_high().unwrap();

--- a/src/embassy/mod.rs
+++ b/src/embassy/mod.rs
@@ -1,0 +1,9 @@
+use time_driver::{Bus, EmbassyTimeDriver, Timer};
+
+use crate::rcu::Clocks;
+
+mod time_driver;
+
+pub fn init(timer: Timer, clocks: &Clocks, apb: &mut Bus) {
+    EmbassyTimeDriver::init(timer, clocks, apb)
+}

--- a/src/embassy/time_driver.rs
+++ b/src/embassy/time_driver.rs
@@ -1,0 +1,401 @@
+use core::cell::Cell;
+use core::convert::TryInto;
+use core::sync::atomic::{compiler_fence, AtomicU32, AtomicU8, Ordering};
+use core::{mem, ptr, u16};
+use critical_section::CriticalSection;
+use embassy_sync::blocking_mutex::{raw::CriticalSectionRawMutex, Mutex};
+use embassy_time_driver::{AlarmHandle, Driver, TICK_HZ};
+
+use crate::pac::{interrupt, Interrupt};
+use crate::rcu::{sealed::RcuBus, Clocks, Enable, GetBusFreq, Reset};
+
+#[cfg(not(any(
+    feature = "time-driver-tim1",
+    feature = "time-driver-tim2",
+    feature = "time-driver-tim14",
+)))]
+compile_error!("Embassy feature enabled however a time driver was not specified. A `--features time-driver-tim<1, 2, 14>` is required.");
+
+#[cfg(any(
+    all(feature = "time-driver-tim1", feature = "time-driver-tim2"),
+    all(feature = "time-driver-tim1", feature = "time-driver-tim14"),
+    all(feature = "time-driver-tim2", feature = "time-driver-tim14"),
+))]
+compile_error!(
+    "Multiple Embassy time drivers are specified. Only a single `--features time-driver-tim<1, 2, 14>` can be specified."
+);
+
+#[cfg(feature = "time-driver-tim1")]
+pub(super) type Timer = crate::pac::Timer1;
+#[cfg(feature = "time-driver-tim2")]
+pub(super) type Timer = crate::pac::Timer2;
+#[cfg(feature = "time-driver-tim14")]
+pub(super) type Timer = crate::pac::Timer14;
+
+#[cfg(any(feature = "time-driver-tim1", feature = "time-driver-tim2"))]
+pub(super) type Bus = crate::rcu::APB1;
+#[cfg(feature = "time-driver-tim14")]
+pub(super) type Bus = crate::rcu::APB2;
+
+#[cfg(any(feature = "time-driver-tim1", feature = "time-driver-tim2"))]
+type RegisterBlock = crate::pac::timer1::RegisterBlock;
+#[cfg(feature = "time-driver-tim14")]
+type RegisterBlock = crate::pac::timer14::RegisterBlock;
+
+// NOTE regarding the ALARM_COUNT:
+//
+// This driver is implemented using CC0 as the halfway rollover interrupt, and any additional CC
+// capabilities to provide timer alarms to embassy-time.
+// Hence, only general-purpose timer instances with two or more channels are allowed:
+// - TIMER1, TIMER2 - 4 channels
+// - TIMER14 - 2 channels
+
+#[cfg(any(feature = "time-driver-tim1", feature = "time-driver-tim2"))]
+const ALARM_COUNT: usize = 3;
+
+#[cfg(feature = "time-driver-tim14")]
+const ALARM_COUNT: usize = 1;
+
+fn timer() -> &'static RegisterBlock {
+    unsafe { &*Timer::PTR }
+}
+
+struct AlarmState {
+    timestamp: Cell<u64>,
+
+    // This is really a Option<(fn(*mut ()), *mut ())>
+    // but fn pointers aren't allowed in const yet
+    callback: Cell<*const ()>,
+    ctx: Cell<*mut ()>,
+}
+
+unsafe impl Send for AlarmState {}
+
+impl AlarmState {
+    const fn new() -> Self {
+        Self {
+            timestamp: Cell::new(u64::MAX),
+            callback: Cell::new(ptr::null()),
+            ctx: Cell::new(ptr::null_mut()),
+        }
+    }
+}
+
+// NOTE: this definitely could be improved in the PAC crate
+// An alternative would be to use a pointer-based access to the registers
+trait ChannelsAccess {
+    type Counter;
+
+    fn set_chn_cc_value(&self, channel: usize, value: Self::Counter);
+    fn set_chn_ie(&self, channel: usize, value: bool);
+}
+
+#[cfg(any(feature = "time-driver-tim1", feature = "time-driver-tim2"))]
+impl ChannelsAccess for crate::pac::timer1::RegisterBlock {
+    type Counter = u32;
+
+    fn set_chn_cc_value(&self, channel: usize, value: Self::Counter) {
+        match channel {
+            0 => self.ch0cv().write(|w| w.ch0val().bits(value)),
+            1 => self.ch1cv().write(|w| w.ch1val().bits(value)),
+            2 => self.ch2cv().write(|w| w.ch2val().bits(value)),
+            3 => self.ch3cv().write(|w| w.ch3val().bits(value)),
+            _ => return,
+        }
+    }
+
+    fn set_chn_ie(&self, channel: usize, value: bool) {
+        match channel {
+            0 => self.dmainten().modify(|_, w| w.ch0ie().bit(value)),
+            1 => self.dmainten().modify(|_, w| w.ch1ie().bit(value)),
+            2 => self.dmainten().modify(|_, w| w.ch2ie().bit(value)),
+            3 => self.dmainten().modify(|_, w| w.ch3ie().bit(value)),
+            _ => return,
+        };
+    }
+}
+
+#[cfg(feature = "time-driver-tim14")]
+impl ChannelsAccess for crate::pac::timer14::RegisterBlock {
+    type Counter = u16;
+
+    fn set_chn_cc_value(&self, channel: usize, value: Self::Counter) {
+        match channel {
+            0 => self.ch0cv().write(|w| w.ch0val().bits(value)),
+            1 => self.ch1cv().write(|w| w.ch1val().bits(value)),
+            _ => return,
+        }
+    }
+
+    fn set_chn_ie(&self, channel: usize, value: bool) {
+        match channel {
+            0 => self.dmainten().modify(|_, w| w.ch0ie().bit(value)),
+            1 => self.dmainten().modify(|_, w| w.ch1ie().bit(value)),
+            _ => return,
+        };
+    }
+}
+
+// Clock timekeeping works with something we call "periods", which are time intervals
+// of 2^15 ticks. The Clock counter value is 16 bits, so one "overflow cycle" is 2 periods.
+// Timer1 has 32 bits counter, however for a sake of consistency, only 16 bits are used.
+//
+// A `period` count is maintained in parallel to the Timer hardware `counter`, like this:
+// - `period` and `counter` start at 0
+// - `period` is incremented on overflow (at counter value 0)
+// - `period` is incremented "midway" between overflows (at counter value 0x8000)
+//
+// Therefore, when `period` is even, counter is in 0..0x7FFF. When odd, counter is in 0x8000..0xFFFF
+// This allows for now() to return the correct value even if it races an overflow.
+//
+// To get `now()`, `period` is read first, then `counter` is read. If the counter value matches
+// the expected range for the `period` parity, we're done. If it doesn't, this means that
+// a new period start has raced us between reading `period` and `counter`, so we assume the `counter` value
+// corresponds to the next period.
+//
+// `period` is a 32bit unsigned integer, so It overflows on 2^32 * 2^15 / 32768 seconds of uptime, which is 136 years.
+fn calc_now(period: u32, counter: u32) -> u64 {
+    ((period as u64) << 15) + ((counter ^ ((period & 1) << 15)) as u64)
+}
+
+const ALARM_STATE_NEW: AlarmState = AlarmState::new();
+
+pub(super) struct EmbassyTimeDriver {
+    /// Number of 2^31 periods elapsed since boot.
+    period: AtomicU32,
+    alarm_count: AtomicU8,
+    /// Timestamp at which to fire alarm. u64::MAX if no alarm is scheduled.
+    alarms: Mutex<CriticalSectionRawMutex, [AlarmState; ALARM_COUNT]>,
+}
+
+impl EmbassyTimeDriver {
+    pub(super) fn init(timer: Timer, clocks: &Clocks, apb: &mut Bus) {
+        Timer::enable(apb);
+        Timer::reset(apb);
+
+        timer.ctl0().modify(|_, w| w.cen().disabled());
+
+        timer.cnt().write(|w| w.cnt().bits(0));
+
+        let timer_freq = <Timer as RcuBus>::Bus::get_timer_frequency(clocks);
+        // NOTE: using the default 1MHz tick rate
+        let psc = (timer_freq.0 as u64) / TICK_HZ - 1;
+        let psc: u16 = match psc.try_into() {
+            Err(_) => panic!("psc division overflow: {}", psc),
+            Ok(n) => n,
+        };
+
+        timer.psc().write(|w| w.psc().bits(psc));
+        timer.car().write(|w| {
+            w.car()
+                .bits(u16::MAX as <RegisterBlock as ChannelsAccess>::Counter)
+        });
+
+        timer.ctl0().modify(|_, w| w.ups().counter_only());
+        timer.swevg().write(|w| w.upg().update());
+        timer.ctl0().modify(|_, w| w.ups().any_event());
+
+        // Half of the u16::MAX value
+        timer.ch0cv().write(|w| w.ch0val().bits(0x8000));
+
+        timer
+            .dmainten()
+            .modify(|_, w| w.upie().enabled().ch0ie().enabled());
+
+        #[cfg(feature = "time-driver-tim1")]
+        {
+            unsafe {
+                cortex_m::peripheral::NVIC::unmask(Interrupt::TIMER1);
+            }
+        }
+        #[cfg(feature = "time-driver-tim2")]
+        {
+            unsafe {
+                cortex_m::peripheral::NVIC::unmask(Interrupt::TIMER2);
+            }
+        }
+        #[cfg(feature = "time-driver-tim14")]
+        {
+            unsafe {
+                cortex_m::peripheral::NVIC::unmask(Interrupt::TIMER14);
+            }
+        }
+
+        timer.ctl0().modify(|_, w| w.cen().enabled());
+    }
+
+    fn get_alarm<'a>(&'a self, cs: CriticalSection<'a>, alarm: AlarmHandle) -> &'a AlarmState {
+        // safety: we're allowed to assume the AlarmState is created by us, and
+        // we never create one that's out of bounds.
+        unsafe { self.alarms.borrow(cs).get_unchecked(alarm.id() as usize) }
+    }
+
+    fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
+        let alarm = &self.alarms.borrow(cs)[n];
+        alarm.timestamp.set(u64::MAX);
+        // Call after clearing alarm, so the callback can set another alarm.
+
+        // Safety:
+        // - we can ignore the possibility of `f` being unset (null) because of the safety contract of `allocate_alarm`.
+        // - other than that we only store valid function pointers into alarm.callback
+        let f: fn(*mut ()) = unsafe { mem::transmute(alarm.callback.get()) };
+        f(alarm.ctx.get());
+    }
+
+    fn on_interrupt(&self) {
+        let r = timer();
+
+        critical_section::with(|cs| {
+            let status = r.intf().read();
+            let enabled = r.dmainten().read();
+
+            // Clear all interrupt flags. Bits in SR are "write 0 to clear", so write the bitwise NOT.
+            // Other approaches such as writing all zeros, or RMWing won't work, they can
+            // miss interrupts.
+            r.intf().write(|w| unsafe { w.bits(!status.bits()) });
+
+            if status.upif().bit() {
+                self.next_period()
+            }
+
+            if status.ch0if().bit() {
+                self.next_period()
+            }
+
+            for n in 0..ALARM_COUNT {
+                // Bit 0 indicates Update CC interrupt, bit 1 corresponds to reserved Channel 0
+                let channel = n + 2;
+                if ((enabled.bits() >> channel) & 1 != 0) && ((status.bits() >> channel) & 1 != 0) {
+                    self.trigger_alarm(n, cs);
+                }
+            }
+        })
+    }
+
+    fn next_period(&self) {
+        let r = timer();
+
+        // We only modify the period from the timer interrupt, so we know this can't race.
+        let period = self.period.load(Ordering::Relaxed) + 1;
+        self.period.store(period, Ordering::Relaxed);
+        let t = (period as u64) << 15;
+
+        critical_section::with(move |cs| {
+            for n in 0..ALARM_COUNT {
+                let alarm = &self.alarms.borrow(cs)[n];
+                let at = alarm.timestamp.get();
+
+                if at < t + 0xc000 {
+                    // just enable it. `set_alarm` has already set the correct CCR val.
+                    r.set_chn_ie(n + 1, true);
+                }
+            }
+        })
+    }
+}
+
+impl Driver for EmbassyTimeDriver {
+    fn now(&self) -> u64 {
+        let r = timer();
+        let period = self.period.load(Ordering::Relaxed);
+        compiler_fence(Ordering::Acquire);
+        // Timer1 has a 32-bit counter, while other timers resolution is limited to 16 bits
+        let counter = r.cnt().read().cnt().bits() as u32;
+
+        calc_now(period, counter)
+    }
+
+    unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {
+        critical_section::with(|_| {
+            let id = self.alarm_count.load(Ordering::Relaxed);
+            if id < ALARM_COUNT as u8 {
+                self.alarm_count.store(id + 1, Ordering::Relaxed);
+                Some(AlarmHandle::new(id))
+            } else {
+                None
+            }
+        })
+    }
+
+    fn set_alarm_callback(&self, alarm: AlarmHandle, callback: fn(*mut ()), ctx: *mut ()) {
+        critical_section::with(|cs| {
+            let alarm = self.get_alarm(cs, alarm);
+
+            alarm.callback.set(callback as *const ());
+            alarm.ctx.set(ctx);
+        })
+    }
+
+    fn set_alarm(&self, alarm: AlarmHandle, timestamp: u64) -> bool {
+        critical_section::with(|cs| {
+            let r = timer();
+
+            let n = alarm.id() as usize;
+            let alarm = self.get_alarm(cs, alarm);
+            alarm.timestamp.set(timestamp);
+
+            let t = self.now();
+            if timestamp <= t {
+                // If alarm timestamp has passed the alarm will not fire.
+                // Disarm the alarm and return `false` to indicate that.
+                r.set_chn_ie(n + 1, false);
+
+                alarm.timestamp.set(u64::MAX);
+
+                return false;
+            }
+
+            // Write the CCR value regardless of whether we're going to enable it now or not.
+            // This way, when we enable it later, the right value is already set.
+            r.set_chn_cc_value(
+                n + 1,
+                timestamp as <RegisterBlock as ChannelsAccess>::Counter,
+            );
+
+            // Enable it if it'll happen soon. Otherwise, `next_period` will enable it.
+            let diff = timestamp - t;
+            r.set_chn_ie(n + 1, diff < 0xc000);
+
+            // Reevaluate if the alarm timestamp is still in the future
+            let t = self.now();
+            if timestamp <= t {
+                // If alarm timestamp has passed since we set it, we have a race condition and
+                // the alarm may or may not have fired.
+                // Disarm the alarm and return `false` to indicate that.
+                // It is the caller's responsibility to handle this ambiguity.
+                r.set_chn_ie(n + 1, false);
+
+                alarm.timestamp.set(u64::MAX);
+
+                return false;
+            }
+
+            // We're confident the alarm will ring in the future.
+            true
+        })
+    }
+}
+
+embassy_time_driver::time_driver_impl!(static DRIVER: EmbassyTimeDriver = EmbassyTimeDriver{
+    period: AtomicU32::new(0),
+    alarm_count: AtomicU8::new(0),
+    alarms: Mutex::const_new(CriticalSectionRawMutex::new(), [ALARM_STATE_NEW; ALARM_COUNT]),
+});
+
+#[cfg(feature = "time-driver-tim1")]
+#[interrupt]
+fn TIMER1() {
+    DRIVER.on_interrupt()
+}
+
+#[cfg(feature = "time-driver-tim2")]
+#[interrupt]
+fn TIMER2() {
+    DRIVER.on_interrupt()
+}
+
+#[cfg(feature = "time-driver-tim14")]
+#[interrupt]
+fn TIMER14() {
+    DRIVER.on_interrupt()
+}

--- a/src/embassy/time_driver.rs
+++ b/src/embassy/time_driver.rs
@@ -1,20 +1,23 @@
-use core::cell::Cell;
+use core::cell::{Cell, RefCell};
 use core::convert::TryInto;
-use core::sync::atomic::{compiler_fence, AtomicU32, AtomicU8, Ordering};
+use core::sync::atomic::{AtomicU32, Ordering, compiler_fence};
 use core::u16;
 use critical_section::CriticalSection;
-use embassy_sync::blocking_mutex::{raw::CriticalSectionRawMutex, Mutex};
-use embassy_time_driver::{AlarmHandle, Driver, TICK_HZ};
+use embassy_sync::blocking_mutex::{Mutex, raw::CriticalSectionRawMutex};
+use embassy_time_driver::{Driver, TICK_HZ};
+use embassy_time_queue_utils::Queue;
 
-use crate::pac::{interrupt, Interrupt};
-use crate::rcu::{sealed::RcuBus, Clocks, Enable, GetBusFreq, Reset};
+use crate::pac::{Interrupt, interrupt};
+use crate::rcu::{Clocks, Enable, GetBusFreq, Reset, sealed::RcuBus};
 
 #[cfg(not(any(
     feature = "time-driver-tim1",
     feature = "time-driver-tim2",
     feature = "time-driver-tim14",
 )))]
-compile_error!("Embassy feature enabled however a time driver was not specified. A `--features time-driver-tim<1, 2, 14>` is required.");
+compile_error!(
+    "Embassy feature enabled however a time driver was not specified. A `--features time-driver-tim<1, 2, 14>` is required."
+);
 
 #[cfg(any(
     all(feature = "time-driver-tim1", feature = "time-driver-tim2"),
@@ -42,39 +45,24 @@ type RegisterBlock = crate::pac::timer1::RegisterBlock;
 #[cfg(feature = "time-driver-tim14")]
 type RegisterBlock = crate::pac::timer14::RegisterBlock;
 
-// NOTE regarding the ALARM_COUNT:
-//
-// This driver is implemented using CC0 as the halfway rollover interrupt, and any additional CC
-// capabilities to provide timer alarms to embassy-time.
-// Hence, only general-purpose timer instances with two or more channels are allowed:
-// - TIMER1, TIMER2 - 4 channels
-// - TIMER14 - 2 channels
-
-#[cfg(any(feature = "time-driver-tim1", feature = "time-driver-tim2"))]
-const ALARM_COUNT: usize = 3;
-
-#[cfg(feature = "time-driver-tim14")]
-const ALARM_COUNT: usize = 1;
-
 fn timer() -> &'static RegisterBlock {
     unsafe { &*Timer::PTR }
 }
 
 struct AlarmState {
     timestamp: Cell<u64>,
-    callback: Cell<Option<(fn(*mut ()), *mut ())>>,
 }
-
-unsafe impl Send for AlarmState {}
 
 impl AlarmState {
     const fn new() -> Self {
         Self {
             timestamp: Cell::new(u64::MAX),
-            callback: Cell::new(None),
         }
     }
 }
+
+/// As any mutation of this internal type is done within a critical section, the Send implementation is sound
+unsafe impl Send for AlarmState {}
 
 // NOTE: this definitely could be improved in the PAC crate
 // An alternative would be to use a pointer-based access to the registers
@@ -153,14 +141,11 @@ fn calc_now(period: u32, counter: u32) -> u64 {
     ((period as u64) << 15) + ((counter ^ ((period & 1) << 15)) as u64)
 }
 
-const ALARM_STATE_NEW: AlarmState = AlarmState::new();
-
 pub(super) struct EmbassyTimeDriver {
     /// Number of 2^31 periods elapsed since boot.
     period: AtomicU32,
-    alarm_count: AtomicU8,
-    /// Timestamp at which to fire alarm. u64::MAX if no alarm is scheduled.
-    alarms: Mutex<CriticalSectionRawMutex, [AlarmState; ALARM_COUNT]>,
+    alarm: Mutex<CriticalSectionRawMutex, AlarmState>,
+    queue: Mutex<CriticalSectionRawMutex, RefCell<Queue>>,
 }
 
 impl EmbassyTimeDriver {
@@ -219,23 +204,6 @@ impl EmbassyTimeDriver {
         timer.ctl0().modify(|_, w| w.cen().enabled());
     }
 
-    fn get_alarm<'a>(&'a self, cs: CriticalSection<'a>, alarm: AlarmHandle) -> &'a AlarmState {
-        // safety: we're allowed to assume the AlarmState is created by us, and
-        // we never create one that's out of bounds.
-        unsafe { self.alarms.borrow(cs).get_unchecked(alarm.id() as usize) }
-    }
-
-    fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
-        let alarm = &self.alarms.borrow(cs)[n];
-        alarm.timestamp.set(u64::MAX);
-        // Call after clearing alarm, so the callback can set another alarm.
-
-        // The callback must have been set by `allocate_alarm` so this shouldn't panic.
-        let callback = alarm.callback.get().unwrap();
-        let f: fn(*mut ()) = callback.0;
-        f(callback.1);
-    }
-
     fn on_interrupt(&self) {
         let r = timer();
 
@@ -256,12 +224,10 @@ impl EmbassyTimeDriver {
                 self.next_period()
             }
 
-            for n in 0..ALARM_COUNT {
-                // Bit 0 indicates Update CC interrupt, bit 1 corresponds to reserved Channel 0
-                let channel = n + 2;
-                if ((enabled.bits() >> channel) & 1 != 0) && ((status.bits() >> channel) & 1 != 0) {
-                    self.trigger_alarm(n, cs);
-                }
+            // Bit 0 indicates Update CC interrupt, bit 1 corresponds to reserved Channel 0
+            let channel = 2u8;
+            if ((enabled.bits() >> channel) & 1 != 0) && ((status.bits() >> channel) & 1 != 0) {
+                self.trigger_alarm(cs);
             }
         })
     }
@@ -275,16 +241,77 @@ impl EmbassyTimeDriver {
         let t = (period as u64) << 15;
 
         critical_section::with(move |cs| {
-            for n in 0..ALARM_COUNT {
-                let alarm = &self.alarms.borrow(cs)[n];
-                let at = alarm.timestamp.get();
+            let n = 0;
+            let alarm = &self.alarm.borrow(cs);
+            let at = alarm.timestamp.get();
 
-                if at < t + 0xc000 {
-                    // just enable it. `set_alarm` has already set the correct CCR val.
-                    r.set_chn_ie(n + 1, true);
-                }
+            if at < t + 0xc000 {
+                // just enable it. `set_alarm` has already set the correct CCR val.
+                r.set_chn_ie(n + 1, true);
             }
         })
+    }
+
+    fn trigger_alarm(&self, cs: CriticalSection) {
+        let mut next = self
+            .queue
+            .borrow(cs)
+            .borrow_mut()
+            .next_expiration(self.now());
+
+        while !self.set_alarm(cs, next) {
+            next = self
+                .queue
+                .borrow(cs)
+                .borrow_mut()
+                .next_expiration(self.now());
+        }
+    }
+
+    fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
+        let r = timer();
+
+        let n = 0;
+        self.alarm.borrow(cs).timestamp.set(timestamp);
+
+        let t = self.now();
+        if timestamp <= t {
+            // If alarm timestamp has passed the alarm will not fire.
+            // Disarm the alarm and return `false` to indicate that.
+            r.set_chn_ie(n + 1, false);
+
+            self.alarm.borrow(cs).timestamp.set(u64::MAX);
+
+            return false;
+        }
+
+        // Write the CCR value regardless of whether we're going to enable it now or not.
+        // This way, when we enable it later, the right value is already set.
+        r.set_chn_cc_value(
+            n + 1,
+            timestamp as <RegisterBlock as ChannelsAccess>::Counter,
+        );
+
+        // Enable it if it'll happen soon. Otherwise, `next_period` will enable it.
+        let diff = timestamp - t;
+        r.set_chn_ie(n + 1, diff < 0xc000);
+
+        // Reevaluate if the alarm timestamp is still in the future
+        let t = self.now();
+        if timestamp <= t {
+            // If alarm timestamp has passed since we set it, we have a race condition and
+            // the alarm may or may not have fired.
+            // Disarm the alarm and return `false` to indicate that.
+            // It is the caller's responsibility to handle this ambiguity.
+            r.set_chn_ie(n + 1, false);
+
+            self.alarm.borrow(cs).timestamp.set(u64::MAX);
+
+            return false;
+        }
+
+        // We're confident the alarm will ring in the future.
+        true
     }
 }
 
@@ -294,85 +321,29 @@ impl Driver for EmbassyTimeDriver {
         let period = self.period.load(Ordering::Relaxed);
         compiler_fence(Ordering::Acquire);
         // Timer1 has a 32-bit counter, while other timers resolution is limited to 16 bits
-        let counter = r.cnt().read().cnt().bits() as u32;
+        let counter = r.cnt().read().cnt().bits().into();
 
         calc_now(period, counter)
     }
 
-    unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {
-        critical_section::with(|_| {
-            let id = self.alarm_count.load(Ordering::Relaxed);
-            if id < ALARM_COUNT as u8 {
-                self.alarm_count.store(id + 1, Ordering::Relaxed);
-                Some(AlarmHandle::new(id))
-            } else {
-                None
-            }
-        })
-    }
-
-    fn set_alarm_callback(&self, alarm: AlarmHandle, callback: fn(*mut ()), ctx: *mut ()) {
+    fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
         critical_section::with(|cs| {
-            let alarm = self.get_alarm(cs, alarm);
+            let mut queue = self.queue.borrow(cs).borrow_mut();
 
-            alarm.callback.set(Some((callback, ctx)));
-        })
-    }
-
-    fn set_alarm(&self, alarm: AlarmHandle, timestamp: u64) -> bool {
-        critical_section::with(|cs| {
-            let r = timer();
-
-            let n = alarm.id() as usize;
-            let alarm = self.get_alarm(cs, alarm);
-            alarm.timestamp.set(timestamp);
-
-            let t = self.now();
-            if timestamp <= t {
-                // If alarm timestamp has passed the alarm will not fire.
-                // Disarm the alarm and return `false` to indicate that.
-                r.set_chn_ie(n + 1, false);
-
-                alarm.timestamp.set(u64::MAX);
-
-                return false;
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now());
+                while !self.set_alarm(cs, next) {
+                    next = queue.next_expiration(self.now());
+                }
             }
-
-            // Write the CCR value regardless of whether we're going to enable it now or not.
-            // This way, when we enable it later, the right value is already set.
-            r.set_chn_cc_value(
-                n + 1,
-                timestamp as <RegisterBlock as ChannelsAccess>::Counter,
-            );
-
-            // Enable it if it'll happen soon. Otherwise, `next_period` will enable it.
-            let diff = timestamp - t;
-            r.set_chn_ie(n + 1, diff < 0xc000);
-
-            // Reevaluate if the alarm timestamp is still in the future
-            let t = self.now();
-            if timestamp <= t {
-                // If alarm timestamp has passed since we set it, we have a race condition and
-                // the alarm may or may not have fired.
-                // Disarm the alarm and return `false` to indicate that.
-                // It is the caller's responsibility to handle this ambiguity.
-                r.set_chn_ie(n + 1, false);
-
-                alarm.timestamp.set(u64::MAX);
-
-                return false;
-            }
-
-            // We're confident the alarm will ring in the future.
-            true
         })
     }
 }
 
 embassy_time_driver::time_driver_impl!(static DRIVER: EmbassyTimeDriver = EmbassyTimeDriver{
     period: AtomicU32::new(0),
-    alarm_count: AtomicU8::new(0),
-    alarms: Mutex::const_new(CriticalSectionRawMutex::new(), [ALARM_STATE_NEW; ALARM_COUNT]),
+    alarm: Mutex::const_new(CriticalSectionRawMutex::new(), AlarmState::new()),
+    queue: Mutex::new(RefCell::new(Queue::new()))
 });
 
 #[cfg(feature = "time-driver-tim1")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,3 +173,6 @@ pub mod timer;
 pub mod usb;*/
 #[cfg(feature = "device-selected")]
 pub mod watchdog;
+
+#[cfg(feature = "embassy")]
+pub mod embassy;


### PR DESCRIPTION
Resolves #49 

Embassy time driver implementation is mostly a copy-pasta of [the STM32 driver](https://github.com/embassy-rs/embassy/blob/1cf778904d597a5bc01a4b7862f965681636faf1/embassy-stm32/src/time_driver.rs#L275) except it's not implementing RTC functionality required for low-power/deep-sleep scenarios in order to keep it simple (AFAIK current HAL implementation also lacks of RTC support). 

This PR brings a set of new features:
- `embassy` - enables Embassy support in general
- `time-driver-tim<1, 2, 14>` - enables Embassy time driver support for a specified general-purpose timer instance

Both features are required to use the Embassy executor, so any of the `time-driver-tim<1, 2, 14>` features enables the `embassy` feature in general.

Despite that the driver uses `unsafe` access to the selected timer's registry, in order to guard an access to a `TIMERx` peripheral, the driver initialization requires to move a `timer<1, 2, 14>` so it couldn't be used anywhere else causing undefined behavior, ex:
```rust
embassy::init(p.timer1, &clocks, &mut rcu.apb1);
```
After that the `p.timer1` could not be moved, to create a `Timer::timer1`, for example.

Please take into account that Embassy support comes with a price, as a binary relying on the `embassy` feature and using the `async` executor would have additional ~2KiB added to it's size (also an extra memory would be required for the tasks arena):
```bash
> cargo bloat --release --features gd32f130x8,time-driver-tim1 --example embassy
...
File  .text   Size            Crate Name
0.4%  41.9% 1.4KiB embassy_executor embassy_executor::arch::thread::Executor::run
0.2%  20.2%   706B embassy_executor embassy_executor::raw::TaskStorage<F>::poll
0.1%  11.6%   406B     gd32f1x0_hal TIMER1
0.1%  10.5%   366B embassy_executor embassy_executor::raw::TaskStorage<F>::poll
0.0%   4.7%   164B        [Unknown] __aeabi_memclr8
0.0%   2.3%    80B embassy_executor embassy_executor::arch::thread::Executor::new
0.0%   1.3%    46B embassy_executor embassy_executor::raw::util::UninitCell<T>::write_in_place
0.0%   1.1%    40B      cortex_m_rt Reset
0.0%   0.7%    24B        [Unknown] HardFaultTrampoline
0.0%   0.6%    20B          embassy embassy::__cortex_m_rt_main
0.0%   0.5%    18B              std core::option::unwrap_failed
0.0%   0.5%    16B     gd32f1x0_hal gd32f1x0_hal::gpio::gpioc::<impl gd32f1x0_hal::gpio::GpioRegExt for gd32f1::gd32f130::gpioc::RegisterBlock>::is_set_low
0.0%   0.5%    16B     gd32f1x0_hal gd32f1x0_hal::gpio::gpioc::<impl gd32f1x0_hal::gpio::GpioRegExt for gd32f1::gd32f130::gpioc::RegisterBlock>::is_low
0.0%   0.4%    14B     gd32f1x0_hal gd32f1x0_hal::gpio::gpioc::<impl gd32f1x0_hal::gpio::GpioRegExt for gd32f1::gd32f130::gpioc::RegisterBlock>::set_high
0.0%   0.4%    14B     gd32f1x0_hal gd32f1x0_hal::gpio::gpioc::<impl gd32f1x0_hal::gpio::GpioRegExt for gd32f1::gd32f130::gpioc::RegisterBlock>::set_low
0.0%   0.3%    10B         cortex_m _critical_section_1_0_release
0.0%   0.2%     8B embassy_executor embassy_executor::raw::SyncExecutor::alarm_callback
0.0%   0.2%     8B              std core::panicking::panic_const::panic_const_async_fn_resumed
0.0%   0.2%     8B              std core::panicking::panic
0.0%   0.2%     8B              std core::panicking::panic_fmt
0.0%   1.1%    38B                  And 9 smaller methods. Use -n N to show more.
0.8% 100.0% 3.4KiB                  .text section size, the file size is 405.7KiB
```