### PR TITLE
Fix/enable wait states after setting the counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,9 +319,9 @@ checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "gd32f1"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb728df95bc4a2e59020223c9e3a96a74c3e8a5a0c93e61d494b297666a2e4f"
+checksum = "f6f4454c039df9531361e25ee37d4024145b0fefc0d15141250e6d194fc70fb2"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.7", features = [
   "unproven",
 ], optional = true }
 embedded-io = "0.7.1"
-gd32f1 = { version = "0.9.1", features = ["critical-section"] }
+gd32f1 = { version = "0.9.2", features = ["critical-section"] }
 nb = "1.1.0"
 thiserror = { version = "2.0.18", default-features = false }
 void = { version = "1.0.2", default-features = false, optional = true }

--- a/examples/adc-dma-circ.rs
+++ b/examples/adc-dma-circ.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
     // clock is configurable. So its frequency may be tweaked to meet certain
     // practical needs. User specified value is be approximated using supported
     // prescaler values 2/4/6/8.
-    let clocks = rcu.cfgr.adcclk(2.mhz()).freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.adcclk(2.mhz()).freeze(&mut flash);
 
     let dma_ch0 = p.dma.split(&mut rcu.ahb).0;
 

--- a/examples/adc-dma-rx.rs
+++ b/examples/adc-dma-rx.rs
@@ -21,7 +21,7 @@ fn main() -> ! {
     // clock is configurable. So its frequency may be tweaked to meet certain
     // practical needs. User specified value is be approximated using supported
     // prescaler values 2/4/6/8.
-    let clocks = rcu.cfgr.adcclk(2.mhz()).freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.adcclk(2.mhz()).freeze(&mut flash);
 
     let dma_ch0 = p.dma.split(&mut rcu.ahb).0;
 

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
     // clock is configurable. So its frequency may be tweaked to meet certain
     // practical needs. User specified value is be approximated using supported
     // prescaler values 2/4/6/8.
-    let clocks = rcu.cfgr.adcclk(2.mhz()).freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.adcclk(2.mhz()).freeze(&mut flash);
     hprintln!("adc freq: {}", clocks.adcclk().0);
 
     // Setup ADC

--- a/examples/adc_temperature.rs
+++ b/examples/adc_temperature.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
         .sysclk(56.mhz())
         .pclk1(28.mhz())
         .adcclk(14.mhz())
-        .freeze(&mut flash.ws);
+        .freeze(&mut flash);
     hprintln!("sysclk freq: {}", clocks.sysclk().0);
     hprintln!("adc freq: {}", clocks.adcclk().0);
 

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
 
     // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
     // `clocks`
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     // Acquire the GPIOC peripheral
     let mut gpioc = dp.gpioc.split(&mut rcu.ahb);

--- a/examples/blinky_generic.rs
+++ b/examples/blinky_generic.rs
@@ -19,7 +19,7 @@ fn main() -> ! {
     let mut rcu = dp.rcu.constrain();
     let mut flash = dp.fmc.constrain();
 
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     // Acquire the GPIO peripherals
     let mut gpioa = dp.gpioa.split(&mut rcu.ahb);

--- a/examples/blinky_timer_irq.rs
+++ b/examples/blinky_timer_irq.rs
@@ -53,11 +53,7 @@ fn main() -> ! {
 
     let mut flash = dp.fmc.constrain();
     let mut rcu = dp.rcu.constrain();
-    let clocks = rcu
-        .cfgr
-        .sysclk(8.mhz())
-        .pclk1(8.mhz())
-        .freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.sysclk(8.mhz()).pclk1(8.mhz()).freeze(&mut flash);
 
     // Configure PC13 pin to blink LED
     let mut gpioc = dp.gpioc.split(&mut rcu.ahb);

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -18,7 +18,7 @@ fn main() -> ! {
     let mut rcu = dp.rcu.constrain();
     let mut flash = dp.fmc.constrain();
 
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     let mut gpioc = dp.gpioc.split(&mut rcu.ahb);
 

--- a/examples/embassy.rs
+++ b/examples/embassy.rs
@@ -31,7 +31,7 @@ async fn main(spawner: Spawner) {
     let p = pac::Peripherals::take().unwrap();
     let mut rcu = p.rcu.constrain();
     let mut flash = p.fmc.constrain();
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     embassy::init(p.timer1, &clocks, &mut rcu.apb1);
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
     let mut rcu = p.rcu.constrain();
     let mut flash = p.fmc.constrain();
 
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     let mut gpioa = p.gpioa.split(&mut rcu.ahb);
 

--- a/examples/pwm_complementary.rs
+++ b/examples/pwm_complementary.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
     let mut rcu = p.rcu.constrain();
     let mut flash = p.fmc.constrain();
 
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     let mut gpioa = p.gpioa.split(&mut rcu.ahb);
     let mut gpiob = p.gpiob.split(&mut rcu.ahb);

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
     let mut flash = p.fmc.constrain();
     let mut rcu = p.rcu.constrain();
 
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     let channels = p.dma.split(&mut rcu.ahb);
 

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     let mut flash = p.fmc.constrain();
     let mut rcu = p.rcu.constrain();
 
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     let channels = p.dma.split(&mut rcu.ahb);
 

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     let mut flash = p.fmc.constrain();
     let mut rcu = p.rcu.constrain();
 
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     let channels = p.dma.split(&mut rcu.ahb);
 

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     let mut flash = p.fmc.constrain();
     let mut rcu = p.rcu.constrain();
 
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     let channels = p.dma.split(&mut rcu.ahb);
 

--- a/examples/serial-fmt.rs
+++ b/examples/serial-fmt.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
 
     // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
     // `clocks`.
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     // Prepare the GPIOA peripheral
     let mut gpioa = p.gpioa.split(&mut rcu.ahb);

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
 
     // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
     // `clocks`.
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     // Prepare the GPIOA peripheral
     let mut gpioa = p.gpioa.split(&mut rcu.ahb);

--- a/examples/serial_config.rs
+++ b/examples/serial_config.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
 
     // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
     // `clocks`.
-    let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    let clocks = rcu.cfgr.freeze(&mut flash);
 
     // Prepare the GPIOA peripheral
     let mut gpioa = p.gpioa.split(&mut rcu.ahb);

--- a/examples/timer-interrupt-rtic.rs
+++ b/examples/timer-interrupt-rtic.rs
@@ -48,7 +48,7 @@ mod app {
 
         // Freeze the configuration of all the clocks in the system and store the frozen frequencies
         // in `clocks`
-        let clocks = rcu.cfgr.freeze(&mut flash.ws);
+        let clocks = rcu.cfgr.freeze(&mut flash);
 
         // Acquire the GPIOC peripheral
         let mut gpioc = cx.device.gpioc.split(&mut rcu.ahb);

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -4,6 +4,8 @@
 
 //! Flash memory
 
+use gd32f1::gd32f130::fmc::wsen;
+
 use crate::pac::{Fmc, fmc};
 
 pub const FLASH_START: u32 = 0x0800_0000;
@@ -368,6 +370,23 @@ impl WS {
     pub(crate) fn ws(&mut self) -> &fmc::Ws {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { (*Fmc::ptr()).ws() }
+    }
+
+    /// Enable flash wait states (set WSEN=1).
+    ///
+    /// WSCNT has no effect until this bit is set (GD32F1x0 manual §2.4.9).
+    /// The FMC must be unlocked first via the key sequence, then re-locked.
+    pub(crate) fn enable_wait_states(&mut self) {
+        let fmc = unsafe { &*Fmc::ptr() };
+        while fmc.stat().read().busy().is_active() {}
+        // Unlock FMC control register
+        fmc.key().write(|w| w.key().bits(KEY1));
+        fmc.key().write(|w| w.key().bits(KEY2));
+
+        fmc.wsen().write(|w| w.wsen().wait_state());
+
+        // Re-lock
+        fmc.ctl().modify(|_, w| w.lk().lock());
     }
 }
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -4,8 +4,6 @@
 
 //! Flash memory
 
-use gd32f1::gd32f130::fmc::wsen;
-
 use crate::pac::{Fmc, fmc};
 
 pub const FLASH_START: u32 = 0x0800_0000;
@@ -83,36 +81,11 @@ pub struct FlashWriter<'a> {
 
 impl<'a> FlashWriter<'a> {
     fn unlock(&mut self) -> Result<()> {
-        // Wait for any ongoing operations
-        while self.fmc.stat.stat().read().busy().is_active() {}
-
-        // NOTE(unsafe) write Keys to the key register. This is safe because the
-        // only side effect of these writes is to unlock the fmc control
-        // register, which is the intent of this function. Do not rearrange the
-        // order of these writes or the control register will be permanently
-        // locked out until reset.
-        self.fmc.key.keyr().write(|w| w.key().bits(KEY1));
-        self.fmc.key.keyr().write(|w| w.key().bits(KEY2));
-
-        // Verify success
-        match self.fmc.ctl.ctl().read().lk().is_unlocked() {
-            true => Ok(()),
-            false => Err(Error::UnlockError),
-        }
+        self.fmc.unlock()
     }
 
     fn lock(&mut self) -> Result<()> {
-        // Wait for ongoing flash operations
-        while self.fmc.stat.stat().read().busy().is_active() {}
-
-        // Set lock bit
-        self.fmc.ctl.ctl().modify(|_, w| w.lk().lock());
-
-        // Verify success
-        match self.fmc.ctl.ctl().read().lk().is_locked() {
-            true => Ok(()),
-            false => Err(Error::LockError),
-        }
+        self.fmc.lock()
     }
 
     fn valid_address(&self, offset: u32) -> Result<()> {
@@ -312,6 +285,7 @@ impl FlashExt for Fmc {
     fn constrain(self) -> Parts {
         Parts {
             ws: WS { _0: () },
+            wsen: WSEN { _0: () },
             addr: ADDR { _0: () },
             ctl: CTL { _0: () },
             key: KEY { _0: () },
@@ -327,6 +301,9 @@ impl FlashExt for Fmc {
 pub struct Parts {
     /// Opaque WS register
     pub ws: WS,
+
+    /// Opaque WSEN register
+    pub wsen: WSEN,
 
     /// Opaque ADDR register
     pub(crate) addr: ADDR,
@@ -358,6 +335,45 @@ impl Parts {
             verify: true,
         }
     }
+
+    pub fn unlock(&mut self) -> Result<()> {
+        // Wait for any ongoing operations
+        while self.stat.stat().read().busy().is_active() {}
+
+        // NOTE(unsafe) write Keys to the key register. This is safe because the
+        // only side effect of these writes is to unlock the fmc control
+        // register, which is the intent of this function. Do not rearrange the
+        // order of these writes or the control register will be permanently
+        // locked out until reset.
+        self.key.keyr().write(|w| w.key().bits(KEY1));
+        self.key.keyr().write(|w| w.key().bits(KEY2));
+
+        // Verify success
+        match self.ctl.ctl().read().lk().is_unlocked() {
+            true => Ok(()),
+            false => Err(Error::UnlockError),
+        }
+    }
+
+    pub fn lock(&mut self) -> Result<()> {
+        // Wait for ongoing flash operations
+        while self.stat.stat().read().busy().is_active() {}
+
+        // Set lock bit
+        self.ctl.ctl().modify(|_, w| w.lk().lock());
+
+        // Verify success
+        match self.ctl.ctl().read().lk().is_locked() {
+            true => Ok(()),
+            false => Err(Error::LockError),
+        }
+    }
+
+    pub fn enable_wait_states(&mut self) -> Result<()> {
+        self.unlock()?;
+        self.wsen.wsen().write(|w| w.wsen().wait_state());
+        self.lock()
+    }
 }
 
 /// Opaque WS register
@@ -370,22 +386,17 @@ impl WS {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { (*Fmc::ptr()).ws() }
     }
+}
 
-    /// Enable flash wait states (set WSEN=1).
-    ///
-    /// WSCNT has no effect until this bit is set (GD32F1x0 manual §2.4.9).
-    /// The FMC must be unlocked first via the key sequence, then re-locked.
-    pub(crate) fn enable_wait_states(&mut self) {
-        let fmc = unsafe { &*Fmc::ptr() };
-        while fmc.stat().read().busy().is_active() {}
-        // Unlock FMC control register
-        fmc.key().write(|w| w.key().bits(KEY1));
-        fmc.key().write(|w| w.key().bits(KEY2));
+/// Opaque WSEN register
+pub struct WSEN {
+    _0: (),
+}
 
-        fmc.wsen().write(|w| w.wsen().wait_state());
-
-        // Re-lock
-        fmc.ctl().modify(|_, w| w.lk().lock());
+impl WSEN {
+    pub(crate) fn wsen(&mut self) -> &fmc::Wsen {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { (*Fmc::ptr()).wsen() }
     }
 }
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -365,7 +365,6 @@ pub struct WS {
     _0: (),
 }
 
-#[allow(dead_code)]
 impl WS {
     pub(crate) fn ws(&mut self) -> &fmc::Ws {
         // NOTE(unsafe) this proxy grants exclusive access to this register

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
 //! // `clocks`
-//! let clocks = rcu.cfgr.freeze(&mut flash.ws);
+//! let clocks = rcu.cfgr.freeze(&mut flash);
 //! ```
 //!
 //! ## Usage examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! // Take ownership over the raw RCU and FMC devices and convert tem into the corresponding HAL
 //! //  structs.
 //! let mut rcu = dp.rcu.constrain();
-//! let mut flash = p.fmc.constrain();
+//! let mut flash = dp.fmc.constrain();
 //!
 //! // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
 //! // `clocks`

--- a/src/rcu.rs
+++ b/src/rcu.rs
@@ -4,7 +4,7 @@
 
 //! # Reset & Clock Unit
 
-use crate::flash::WS;
+use crate::flash::Parts as FmcParts;
 #[cfg(any(feature = "gd32f130", feature = "gd32f150"))]
 use crate::pac::rcu::cfg0::Usbdpsc;
 use crate::pac::{
@@ -260,9 +260,9 @@ impl CFGR {
     /// let dp = pac::Peripherals::take().unwrap();
     /// let mut flash = dp.fmc.constrain();
     /// let mut rcu = dp.rcu.constrain();
-    /// let clocks = rcu.cfgr.freeze(&mut flash.ws);
+    /// let clocks = rcu.cfgr.freeze(&mut flash);
     /// ```
-    pub fn freeze(self, ws: &mut WS) -> Clocks {
+    pub fn freeze(self, fmc: &mut FmcParts) -> Clocks {
         let pllsrculk = self.hxtal.unwrap_or(IRC8M / 2);
 
         let pllmul = self.sysclk.unwrap_or(pllsrculk) / pllsrculk;
@@ -331,9 +331,10 @@ impl CFGR {
         } else {
             Wscnt::Ws2
         };
-        ws.ws().write(|w| w.wscnt().variant(wscnt));
+        fmc.ws.ws().write(|w| w.wscnt().variant(wscnt));
         if wscnt != Wscnt::Ws0 {
-            ws.enable_wait_states();
+            fmc.enable_wait_states()
+                .expect("Failed to enable flash wait states");
         }
 
         #[cfg(any(feature = "gd32f130", feature = "gd32f150"))]
@@ -452,7 +453,7 @@ pub struct BKP {
 /// let mut rcu = dp.rcu.constrain();
 /// let mut flash = dp.fmc.constrain();
 ///
-/// let clocks = rcu.cfgr.freeze(&mut flash.ws);
+/// let clocks = rcu.cfgr.freeze(&mut flash);
 /// ```
 #[derive(Clone, Copy)]
 pub struct Clocks {

--- a/src/rcu.rs
+++ b/src/rcu.rs
@@ -258,9 +258,9 @@ impl CFGR {
     ///
     /// ```rust
     /// let dp = pac::Peripherals::take().unwrap();
-    /// let mut flash = dp.FLASH.constrain();
+    /// let mut flash = dp.fmc.constrain();
     /// let mut rcu = dp.rcu.constrain();
-    /// let clocks = rcu.cfgr.freeze(&mut flash.acr);
+    /// let clocks = rcu.cfgr.freeze(&mut flash.ws);
     /// ```
     pub fn freeze(self, ws: &mut WS) -> Clocks {
         let pllsrculk = self.hxtal.unwrap_or(IRC8M / 2);
@@ -450,9 +450,9 @@ pub struct BKP {
 /// ```rust
 /// let dp = pac::Peripherals::take().unwrap();
 /// let mut rcu = dp.rcu.constrain();
-/// let mut flash = dp.FLASH.constrain();
+/// let mut flash = dp.fmc.constrain();
 ///
-/// let clocks = rcu.cfgr.freeze(&mut flash.acr);
+/// let clocks = rcu.cfgr.freeze(&mut flash.ws);
 /// ```
 #[derive(Clone, Copy)]
 pub struct Clocks {

--- a/src/rcu.rs
+++ b/src/rcu.rs
@@ -324,15 +324,17 @@ impl CFGR {
         assert!(pclk2 <= 72_000_000);
 
         // adjust flash wait states
-        ws.ws().write(|w| {
-            w.wscnt().variant(if sysclk <= 24_000_000 {
-                Wscnt::Ws0
-            } else if sysclk <= 48_000_000 {
-                Wscnt::Ws1
-            } else {
-                Wscnt::Ws2
-            })
-        });
+        let wscnt = if sysclk <= 24_000_000 {
+            Wscnt::Ws0
+        } else if sysclk <= 48_000_000 {
+            Wscnt::Ws1
+        } else {
+            Wscnt::Ws2
+        };
+        ws.ws().write(|w| w.wscnt().variant(wscnt));
+        if wscnt != Wscnt::Ws0 {
+            ws.enable_wait_states();
+        }
 
         #[cfg(any(feature = "gd32f130", feature = "gd32f150"))]
         // the USB clock is only valid if an external crystal is used, the PLL is enabled, and the


### PR DESCRIPTION
Implements a patch for #70 

I have first implemented it in a "dirty" way and then added the proper (breaking) implementation in a separate commit.

Feel free to drop the last commit if you don't want to break the interface and are fine with the initial implementation.

---

 I have tested it on a `GD32F130F8` by checking the registers before and after setting the clocks:
 
 _before:_
 ``` gdb
# WS
(gdb) x/1xw 0x40022000
0x00000000
# WSEN 
(gdb) x/1xw 0x400220FC
0x00000000 
 ```
 _stepping over:_
 ``` rust
 let clocks = rcc.cfgr.sysclk(48.mhz()).freeze(&mut fmc);
 ```
 _after:_
 ``` gdb
# WS
(gdb) x/1xw 0x40022000
0x00000001 
# WSEN
(gdb) x/1xw 0x400220FC
0x00000001 
 ```
